### PR TITLE
fix(csp): allow blob: web workers so the explore graph renders

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,11 @@ const ContentSecurityPolicy = [
   "img-src 'self' data: blob:",
   "font-src 'self' data:",
   "connect-src 'self'",
+  // The /explore graph (graphology ForceAtlas2 + Sigma) runs its layout in a
+  // Web Worker created from a blob: URL. Allow blob workers explicitly —
+  // otherwise worker-src falls back to script-src and the worker is blocked.
+  "worker-src 'self' blob:",
+  "child-src 'self' blob:",
   "object-src 'none'",
 ].join('; ');
 


### PR DESCRIPTION
## The bug
The `/explore` ForceAtlas node graph was broken in production — the canvas stayed empty. Console error on the live site:

> Creating a worker from 'blob:…' violates the Content Security Policy directive: `"script-src 'self' 'unsafe-inline'"`. Note that 'worker-src' was not explicitly set, so 'script-src' is used as a fallback. The action has been blocked.

## Cause
The graph (graphology-layout-forceatlas2 + Sigma) runs its layout in a **Web Worker created from a `blob:` URL**. The CSP added in the security-hardening pass set `script-src` but no `worker-src`, so `worker-src` fell back to `script-src` (which doesn't allow `blob:`) and the worker was blocked. **Not a data issue** — the graph's data file is untouched.

## Fix
Add `worker-src 'self' blob:` (+ `child-src 'self' blob:` for older browsers) to the CSP. Everything else stays locked down.

## Verification
Built and served locally, loaded `/explore` in a real browser:
- Response header now includes `worker-src 'self' blob:`
- **0 console errors** (was 1 CSP error)
- Full node graph renders (illustrations + keywords)

🤖 Generated with [Claude Code](https://claude.com/claude-code)